### PR TITLE
KEDA: Add `fallback`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - PDB: Add `controller.annotations`. ([#481](https://github.com/giantswarm/ingress-nginx-app/pull/481))
 - Images: Update OpenTelemetry & kube-webhook-certgen image. ([#488](https://github.com/giantswarm/ingress-nginx-app/pull/488))
+- KEDA: Add `fallback`. ([#497](https://github.com/giantswarm/ingress-nginx-app/pull/497))
 
 ### Changed
 

--- a/helm/ingress-nginx/templates/controller-keda.yaml
+++ b/helm/ingress-nginx/templates/controller-keda.yaml
@@ -25,6 +25,11 @@ spec:
   cooldownPeriod: {{ .Values.controller.keda.cooldownPeriod }}
   minReplicaCount: {{ .Values.controller.keda.minReplicas }}
   maxReplicaCount: {{ .Values.controller.keda.maxReplicas }}
+{{- with .Values.controller.keda.fallback }}
+  fallback:
+    failureThreshold: {{ .failureThreshold | default 3 }}
+    replicas: {{ .replicas | default $.Values.controller.keda.maxReplicas }}
+{{- end }}
   triggers:
 {{- with .Values.controller.keda.triggers }}
 {{ toYaml . | indent 2 }}

--- a/helm/ingress-nginx/values.yaml
+++ b/helm/ingress-nginx/values.yaml
@@ -382,6 +382,9 @@ controller:
     maxReplicas: 11
     pollingInterval: 30
     cooldownPeriod: 300
+    # fallback:
+    #   failureThreshold: 3
+    #   replicas: 11
     restoreToOriginalReplicaCount: false
     scaledObject:
       annotations: {}


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once this PR has been submitted.
-->

For changes in the chart, chart templates and container images, I executed the following tests, using the `hello-world` app, to verify them in live environments:

- [ ] Upgrade from previous version
  - [ ] AWS
  - [ ] Azure
- [ ] Existing `Ingress` resources are reconciled
  - [ ] AWS
  - [ ] Azure
- [ ] Fresh install
  - [ ] AWS
  - [ ] Azure
- [ ] Fresh `Ingress` resources are reconciled
  - [ ] AWS
  - [ ] Azure
