### PR TITLE
OpenTelemetry: Add distroless `init_module`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - PDB: Add `controller.annotations`. ([#481](https://github.com/giantswarm/ingress-nginx-app/pull/481))
 - Images: Update OpenTelemetry & kube-webhook-certgen image. ([#488](https://github.com/giantswarm/ingress-nginx-app/pull/488))
 - KEDA: Add `fallback`. ([#497](https://github.com/giantswarm/ingress-nginx-app/pull/497))
+- OpenTelemetry: Add distroless `init_module`. ([#498](https://github.com/giantswarm/ingress-nginx-app/pull/498))
 
 ### Changed
 

--- a/helm/ingress-nginx/templates/_helpers.tpl
+++ b/helm/ingress-nginx/templates/_helpers.tpl
@@ -202,8 +202,12 @@ Extra modules.
 {{- define "extraModules" -}}
 - name: {{ .name }}
   image: {{ .image }}
+  {{- if .distroless | default false }}
+  command: ['/init_module']
+  {{- else }}
   command: ['sh', '-c', '/usr/local/bin/init_module.sh']
-  {{- if (.containerSecurityContext) }}
+  {{- end }}
+  {{- if .containerSecurityContext }}
   securityContext: {{ .containerSecurityContext | toYaml | nindent 4 }}
   {{- end }}
   volumeMounts:

--- a/helm/ingress-nginx/templates/controller-daemonset.yaml
+++ b/helm/ingress-nginx/templates/controller-daemonset.yaml
@@ -182,12 +182,12 @@ spec:
       {{- if .Values.controller.extraModules }}
         {{- range .Values.controller.extraModules }}
           {{- $containerSecurityContext := .containerSecurityContext | default $.Values.controller.containerSecurityContext }}
-          {{- include "extraModules" (dict "name" .name "image" .image "containerSecurityContext" $containerSecurityContext) | nindent 8 }}
+          {{- include "extraModules" (dict "name" .name "image" .image "containerSecurityContext" $containerSecurityContext "distroless" false) | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- if .Values.controller.opentelemetry.enabled}}
           {{- $otelContainerSecurityContext := $.Values.controller.opentelemetry.containerSecurityContext | default $.Values.controller.containerSecurityContext }}
-          {{- include "extraModules" (dict "name" "opentelemetry" "image" .Values.controller.opentelemetry.image "containerSecurityContext" $otelContainerSecurityContext) | nindent 8}}
+          {{- include "extraModules" (dict "name" "opentelemetry" "image" .Values.controller.opentelemetry.image "containerSecurityContext" $otelContainerSecurityContext "distroless" false) | nindent 8}}
       {{- end}}
     {{- end }}
     {{- if .Values.controller.hostNetwork }}

--- a/helm/ingress-nginx/templates/controller-deployment.yaml
+++ b/helm/ingress-nginx/templates/controller-deployment.yaml
@@ -185,12 +185,12 @@ spec:
       {{- if .Values.controller.extraModules }}
         {{- range .Values.controller.extraModules }}
           {{- $containerSecurityContext := .containerSecurityContext | default $.Values.controller.containerSecurityContext }}
-          {{- include "extraModules" (dict "name" .name "image" .image "containerSecurityContext" $containerSecurityContext) | nindent 8 }}
+          {{- include "extraModules" (dict "name" .name "image" .image "containerSecurityContext" $containerSecurityContext "distroless" false) | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- if .Values.controller.opentelemetry.enabled}}
           {{- $otelContainerSecurityContext := $.Values.controller.opentelemetry.containerSecurityContext | default $.Values.controller.containerSecurityContext }}
-          {{- include "extraModules" (dict "name" "opentelemetry" "image" .Values.controller.opentelemetry.image "containerSecurityContext" $otelContainerSecurityContext) | nindent 8}}
+          {{- include "extraModules" (dict "name" "opentelemetry" "image" .Values.controller.opentelemetry.image "containerSecurityContext" $otelContainerSecurityContext "distroless" false) | nindent 8}}
       {{- end}}
     {{- end }}
     {{- if .Values.controller.hostNetwork }}


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once this PR has been submitted.
-->

For changes in the chart, chart templates and container images, I executed the following tests, using the `hello-world` app, to verify them in live environments:

- [ ] Upgrade from previous version
  - [ ] AWS
  - [ ] Azure
- [ ] Existing `Ingress` resources are reconciled
  - [ ] AWS
  - [ ] Azure
- [ ] Fresh install
  - [ ] AWS
  - [ ] Azure
- [ ] Fresh `Ingress` resources are reconciled
  - [ ] AWS
  - [ ] Azure
