### PR TITLE
Deployment: Ignore `replicas` with KEDA enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Repository: Implement `vendir` sync. ([#509](https://github.com/giantswarm/ingress-nginx-app/pull/509))
 - Vendir: Ignore paths. ([#511](https://github.com/giantswarm/ingress-nginx-app/pull/511))
+- Deployment: Ignore `replicaCount` with KEDA enabled. ([#513](https://github.com/giantswarm/ingress-nginx-app/pull/513))
 
 ## [3.0.0-beta1] - 2023-07-13
 

--- a/helm/ingress-nginx/templates/controller-deployment.yaml
+++ b/helm/ingress-nginx/templates/controller-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     matchLabels:
       {{- include "ingress-nginx.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: controller
-  {{- if not .Values.controller.autoscaling.enabled }}
+  {{- if not (or .Values.controller.autoscaling.enabled .Values.controller.keda.enabled) }}
   replicas: {{ .Values.controller.replicaCount }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once this PR has been submitted.
-->

For changes in the chart, chart templates and container images, I executed the following tests, using the `hello-world` app, to verify them in live environments:

- [ ] Upgrade from previous version
  - [ ] AWS
  - [ ] Azure
- [ ] Existing `Ingress` resources are reconciled
  - [ ] AWS
  - [ ] Azure
- [ ] Fresh install
  - [ ] AWS
  - [ ] Azure
- [ ] Fresh `Ingress` resources are reconciled
  - [ ] AWS
  - [ ] Azure
