### PR TITLE
Service: Fix wildcard subdomain.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Deployment/DaemonSet: Make `controller.topologySpreadConstraints` an array. ([#536](https://github.com/giantswarm/ingress-nginx-app/pull/536))\
   **NOTE:** This is part of our alignment to upstream. Please convert any overrides of `controller.topologySpreadConstraints` to an array, too.
 - Tests: Upgrade dependencies & remove explicit ATS version. ([#538](https://github.com/giantswarm/ingress-nginx-app/pull/538))
+- Service: Fix wildcard subdomain. ([#539](https://github.com/giantswarm/ingress-nginx-app/pull/539))
 
 ## [3.0.1] - 2023-09-18
 

--- a/helm/ingress-nginx/templates/controller-service-internal.yaml
+++ b/helm/ingress-nginx/templates/controller-service-internal.yaml
@@ -7,7 +7,7 @@ metadata:
     {{ $key }}: {{ tpl ($value | toString) $ | quote }}
   {{- end }}
   {{- if and .Values.controller.service.externalDNS.enabled .Values.baseDomain }}
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.controller.service.internal.subdomain }}.{{ .Values.baseDomain }}
+    external-dns.alpha.kubernetes.io/hostname: "{{ .Values.controller.service.internal.subdomain }}.{{ .Values.baseDomain }}"
     {{- if .Values.controller.service.externalDNS.annotation }}
     {{ .Values.controller.service.externalDNS.annotation }}
     {{- end }}

--- a/helm/ingress-nginx/templates/controller-service.yaml
+++ b/helm/ingress-nginx/templates/controller-service.yaml
@@ -7,7 +7,7 @@ metadata:
     {{ $key }}: {{ tpl ($value | toString) $ | quote }}
   {{- end }}
   {{- if and .Values.controller.service.externalDNS.enabled .Values.baseDomain }}
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.controller.service.subdomain }}.{{ .Values.baseDomain }}
+    external-dns.alpha.kubernetes.io/hostname: "{{ .Values.controller.service.subdomain }}.{{ .Values.baseDomain }}"
     {{- if .Values.controller.service.externalDNS.annotation }}
     {{ .Values.controller.service.externalDNS.annotation }}
     {{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28355

The error was

```
Error: YAML parse error on ingress-nginx/templates/controller-service.yaml: error converting YAML to JSON: yaml: line 9: did not find expected alphabetic or numeric character
```

Likely the YAML parser saw `external-dns.alpha.kubernetes.io/hostname: *.bla` and instead wanted to see a YAML anchor name. Quote the label value as a simple fix.

Found while testing on CAPA with live customer configuration taken from v2.x of the app.

---

For changes in the chart, chart templates and container images, I executed the following tests, using the `hello-world` app, to verify them in live environments:

**none**