### PR TITLE
Admission Webhooks: Update `kube-webhook-certgen` image to `v20231011-8b53cabe0`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Service: Fix wildcard subdomain. ([#539](https://github.com/giantswarm/ingress-nginx-app/pull/539))
 - Chart: Tighten `securityContext`s and Pod Security Policies. ([#540](https://github.com/giantswarm/ingress-nginx-app/pull/540))
 - OpenTelemetry: Use own registry. ([#541](https://github.com/giantswarm/ingress-nginx-app/pull/541))
+- Admission Webhooks: Update `kube-webhook-certgen` image to `v20231011-8b53cabe0`. ([#542](https://github.com/giantswarm/ingress-nginx-app/pull/542))
 
 ## [3.0.1] - 2023-09-18
 

--- a/helm/ingress-nginx/README.md
+++ b/helm/ingress-nginx/README.md
@@ -124,7 +124,7 @@ Please ensure that cert-manager is correctly installed and configured.
 | controller.admissionWebhooks.patch.image.digest | string | `""` |  |
 | controller.admissionWebhooks.patch.image.image | string | `"giantswarm/ingress-nginx-kube-webhook-certgen"` |  |
 | controller.admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
-| controller.admissionWebhooks.patch.image.tag | string | `"v20230407"` |  |
+| controller.admissionWebhooks.patch.image.tag | string | `"v20231011-8b53cabe0"` |  |
 | controller.admissionWebhooks.patch.labels | object | `{}` | Labels to be added to patch job resources |
 | controller.admissionWebhooks.patch.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
 | controller.admissionWebhooks.patch.podAnnotations | object | `{}` |  |

--- a/helm/ingress-nginx/values.yaml
+++ b/helm/ingress-nginx/values.yaml
@@ -791,7 +791,7 @@ controller:
         ## for backwards compatibility consider setting the full image url via the repository value below
         ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
         ## repository:
-        tag: v20230407
+        tag: v20231011-8b53cabe0
         digest: ""
         pullPolicy: IfNotPresent
       # -- Provide a priority class name to the webhook patching job


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once this PR has been submitted.
-->

For changes in the chart, chart templates and container images, I executed the following tests, using the `hello-world` app, to verify them in live environments:

- [x] Upgrade from previous version
  - [x] AWS
  - [ ] Azure
- [x] Existing `Ingress` resources are reconciled
  - [x] AWS
  - [ ] Azure
- [x] Fresh install
  - [x] AWS
  - [ ] Azure
- [x] Fresh `Ingress` resources are reconciled
  - [x] AWS
  - [ ] Azure
