### PR TITLE
Values: Enable `controller.enableAnnotationValidations` by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Values: Enable `controller.enableAnnotationValidations` by default. ([#552](https://github.com/giantswarm/ingress-nginx-app/pull/552))\
+  **NOTE:** This change affects existing, new & updated `Ingress` resources. Upstream is enabling this by default, too: https://github.com/kubernetes/ingress-nginx/issues/10186.
+
 ## [3.1.1] - 2023-10-18
 
 ### Changed

--- a/helm/ingress-nginx/README.md
+++ b/helm/ingress-nginx/README.md
@@ -162,7 +162,7 @@ Please ensure that cert-manager is correctly installed and configured.
 | controller.dnsConfig | object | `{}` | Optionally customize the pod dnsConfig. |
 | controller.dnsPolicy | string | `"ClusterFirst"` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'. By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller to keep resolving names inside the k8s network, use ClusterFirstWithHostNet. |
 | controller.electionID | string | `""` | Election ID to use for status update, by default it uses the controller name combined with a suffix of 'leader' |
-| controller.enableAnnotationValidations | bool | `false` |  |
+| controller.enableAnnotationValidations | bool | `true` |  |
 | controller.enableMimalloc | bool | `true` | Enable mimalloc as a drop-in replacement for malloc. # ref: https://github.com/microsoft/mimalloc # |
 | controller.enableTopologyAwareRouting | bool | `false` | This configuration enables Topology Aware Routing feature, used together with service annotation service.kubernetes.io/topology-mode="auto" Defaults to false |
 | controller.existingPsp | string | `""` | Use an existing PSP instead of creating one |

--- a/helm/ingress-nginx/values.yaml
+++ b/helm/ingress-nginx/values.yaml
@@ -15,7 +15,7 @@ commonLabels: {}
 
 controller:
   name: controller
-  enableAnnotationValidations: false
+  enableAnnotationValidations: true
   image:
     ## Keep false as default for now!
     chroot: false


### PR DESCRIPTION
<!--
@team-cabbage will be automatically requested for review once this PR has been submitted.
-->

For changes in the chart, chart templates and container images, I executed the following tests, using the `hello-world` app, to verify them in live environments:

- [x] Upgrade from previous version
  - [x] AWS
  - [ ] Azure
- [x] Existing `Ingress` resources are reconciled
  - [x] AWS
  - [ ] Azure
- [x] Fresh install
  - [x] AWS
  - [ ] Azure
- [x] Fresh `Ingress` resources are reconciled
  - [x] AWS
  - [ ] Azure
