### PR TITLE
Explicitly list the providers to test against

### DIFF
--- a/tests/e2e/config.yaml
+++ b/tests/e2e/config.yaml
@@ -1,3 +1,5 @@
 appName: ingress-nginx
 repoName: ingress-nginx-app
 appCatalog: giantswarm
+providers:
+- capa


### PR DESCRIPTION
Explicitly define the CAPI providers to run E2E tests against from PR triggers.

/run app-test-suites