### PR TITLE
Get baseDomain from cluster values instead of default-apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Tests: Bumped `apptest-framework` to latest v1.0.0 release
+- Change E2E tests to pull baseDomain from Cluster values instead of default-apps values
 
 ## [3.6.0] - 2024-03-26
 

--- a/tests/e2e/suites/basic/hello_world.go
+++ b/tests/e2e/suites/basic/hello_world.go
@@ -112,7 +112,7 @@ func newHttpClientWithProxy() *http.Client {
 }
 
 func getWorkloadClusterBaseDomain() string {
-	values := &application.DefaultAppsValues{}
+	values := &application.ClusterValues{}
 	err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
<!--
@team-cabbage will automatically be requested for review once this PR has been submitted.
-->

This PR:

- Uses the values from the cluster chart to get the baseDomain property instead of from the default-apps values. This should allow up to then get rid of the DefaultAppsValues type from clustertest.

This will make things easier when we migrate away from having default-apps.

Related: https://github.com/giantswarm/cluster-test-suites/pull/291

---

## Checklist

- [x] I added a CHANGELOG entry
- [x] I ran E2E tests in the CI pipelines

Add the following comment to trigger the E2E tests:

/run app-test-suites
