### PR TITLE
ServiceMonitor: Add node and app labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- ServiceMonitor: Add `node` and `app` labels. ([]())
+
 ## [3.7.0] - 2024-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- ServiceMonitor: Add `node` and `app` labels. ([]())
+- ServiceMonitor: Add `node` and `app` labels. ([#652](https://github.com/giantswarm/ingress-nginx-app/pull/652))
 
 ## [3.7.0] - 2024-06-03
 

--- a/helm/ingress-nginx/README.md
+++ b/helm/ingress-nginx/README.md
@@ -388,7 +388,12 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.metrics.serviceMonitor.metricRelabelings[0].sourceLabels[0] | string | `"__name__"` |  |
 | controller.metrics.serviceMonitor.namespace | string | `""` |  |
 | controller.metrics.serviceMonitor.namespaceSelector | object | `{}` |  |
-| controller.metrics.serviceMonitor.relabelings | list | `[]` |  |
+| controller.metrics.serviceMonitor.relabelings[0].action | string | `"replace"` |  |
+| controller.metrics.serviceMonitor.relabelings[0].sourceLabels[0] | string | `"__meta_kubernetes_pod_label_app"` |  |
+| controller.metrics.serviceMonitor.relabelings[0].targetLabel | string | `"app"` |  |
+| controller.metrics.serviceMonitor.relabelings[1].action | string | `"replace"` |  |
+| controller.metrics.serviceMonitor.relabelings[1].sourceLabels[0] | string | `"__meta_kubernetes_pod_node_name"` |  |
+| controller.metrics.serviceMonitor.relabelings[1].targetLabel | string | `"node"` |  |
 | controller.metrics.serviceMonitor.scrapeInterval | string | `"30s"` |  |
 | controller.metrics.serviceMonitor.targetLabels | list | `[]` |  |
 | controller.minReadySeconds | int | `0` | `minReadySeconds` to avoid killing pods before we are ready # |

--- a/helm/ingress-nginx/values.yaml
+++ b/helm/ingress-nginx/values.yaml
@@ -898,7 +898,15 @@ controller:
       scrapeInterval: 30s
       # honorLabels: true
       targetLabels: []
-      relabelings: []
+      relabelings:
+        - action: replace
+          sourceLabels:
+          - __meta_kubernetes_pod_label_app
+          targetLabel: app
+        - action: replace
+          sourceLabels:
+          - __meta_kubernetes_pod_node_name
+          targetLabel: node
       metricRelabelings:
       - sourceLabels:
         - __name__

--- a/helm/ingress-nginx/values.yaml
+++ b/helm/ingress-nginx/values.yaml
@@ -899,14 +899,14 @@ controller:
       # honorLabels: true
       targetLabels: []
       relabelings:
-        - action: replace
-          sourceLabels:
-          - __meta_kubernetes_pod_label_app
-          targetLabel: app
-        - action: replace
-          sourceLabels:
-          - __meta_kubernetes_pod_node_name
-          targetLabel: node
+      - action: replace
+        sourceLabels:
+        - __meta_kubernetes_pod_label_app
+        targetLabel: app
+      - action: replace
+        sourceLabels:
+        - __meta_kubernetes_pod_node_name
+        targetLabel: node
       metricRelabelings:
       - sourceLabels:
         - __name__


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will automatically be requested for review once this PR has been submitted.
-->

This PR:

- Add node and app labels to service monitor

Towards https://github.com/giantswarm/giantswarm/issues/30935

---

## Checklist

- [x] I added a CHANGELOG entry
- [ ] I ran E2E tests in the CI pipelines

Add the following comment to trigger the E2E tests:

`/run app-test-suites`
