### PR TITLE
Chart: Add `controller.image.runAsGroup` value for setting the `runAsGroup` field in the container `securityContext`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Chart: Add `controller.image.runAsGroup` value for setting the `runAsGroup` field in the container `securityContext`.
+
 ## [3.9.0] - 2024-07-21
 
 ### Added

--- a/helm/ingress-nginx/README.md
+++ b/helm/ingress-nginx/README.md
@@ -333,6 +333,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.image.image | string | `"giantswarm/ingress-nginx-controller"` |  |
 | controller.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.image.readOnlyRootFilesystem | bool | `false` |  |
+| controller.image.runAsGroup | int | `101` |  |
 | controller.image.runAsNonRoot | bool | `true` |  |
 | controller.image.runAsUser | int | `101` |  |
 | controller.image.seccompProfile.type | string | `"RuntimeDefault"` |  |

--- a/helm/ingress-nginx/templates/_helpers.tpl
+++ b/helm/ingress-nginx/templates/_helpers.tpl
@@ -47,6 +47,7 @@ Controller container security context.
 {{- else -}}
 runAsNonRoot: {{ .Values.controller.image.runAsNonRoot }}
 runAsUser: {{ .Values.controller.image.runAsUser }}
+runAsGroup: {{ .Values.controller.image.runAsGroup }}
 allowPrivilegeEscalation: {{ or .Values.controller.image.allowPrivilegeEscalation .Values.controller.image.chroot }}
 {{- if .Values.controller.image.seccompProfile }}
 seccompProfile: {{ toYaml .Values.controller.image.seccompProfile | nindent 2 }}

--- a/helm/ingress-nginx/values.schema.json
+++ b/helm/ingress-nginx/values.schema.json
@@ -82,6 +82,9 @@
                                         "readOnlyRootFilesystem": {
                                             "type": "boolean"
                                         },
+                                        "runAsGroup": {
+                                            "type": "integer"
+                                        },
                                         "runAsNonRoot": {
                                             "type": "boolean"
                                         },

--- a/helm/ingress-nginx/values.yaml
+++ b/helm/ingress-nginx/values.yaml
@@ -33,6 +33,7 @@ controller:
     runAsNonRoot: true
     # www-data -> uid 101
     runAsUser: 101
+    runAsGroup: 101
     allowPrivilegeEscalation: false
     seccompProfile:
       type: RuntimeDefault


### PR DESCRIPTION
This PR:

- Add `controller.image.runAsGroup` value for setting the `runAsGroup` field in the container `securityContext`. https://github.com/giantswarm/giantswarm/issues/31173

---

## Checklist

- [x] I added a CHANGELOG entry
- [x] I ran E2E tests in the CI pipelines
